### PR TITLE
CRB-299 block_invalid loop

### DIFF
--- a/src/futures/event_result.rs
+++ b/src/futures/event_result.rs
@@ -1,3 +1,4 @@
+#[derive(Debug, PartialEq)]
 pub enum EventResult {
   Continue,
   Restart(bool),

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -178,10 +178,8 @@ impl PowNode {
   }
 
   /// Called when a block check fails
-  fn on_block_invalid(&mut self, block_id: BlockId) -> Result<EventResult, Error> {
-    // Mark the block as failed by consensus, let the validator know
-    self.service.fail_block(block_id)?;
-
+  /// The block has failed, perform cleanup of consensus' state
+  fn on_block_invalid(&mut self, _block_id: BlockId) -> Result<EventResult, Error> {
     Ok(EventResult::Continue)
   }
 

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -505,4 +505,28 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn if_block_is_invalid_then_continue() -> Result<(), Error> {
+    let state = {
+      let mut state = PowState::new();
+      state.peer_id = (&b"aaaaaaaaaaaaaaaa"[..]).into();
+      state
+    };
+
+    let mut node = PowNode {
+      config: PowConfig::new(),
+      service: PowService::new(Box::new(MockService {})),
+      state,
+      miner: Miner::default(),
+    };
+
+    node.state.guards.insert(Guard::Finalized);
+    let blockid = &b"aaffaaffaaffffff"[..];
+    let res = node.on_block_invalid(blockid.into())?;
+
+    assert_eq!(res, EventResult::Continue);
+
+    Ok(())
+  }
 }


### PR DESCRIPTION
The `on_block_invalid` event is meant to clean resources in the consensus, it is not supposed to call the `service` to invalidate blocks; the block has already been through the invalidation pipeline. See [on_block_validated](https://github.com/gluwa/Sawtooth-Core/blob/dev/validator/src/journal/chain.rs#L676) calling the consensus to be notified.