### PR TITLE
CRB-311 expected difficulty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "ccconsensus"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccconsensus"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   "Gluwa Inc.",
   "Vladimir Kuznetsov <vladimir.kouznetsov@gluwa.com>",

--- a/src/block/block_consensus.rs
+++ b/src/block/block_consensus.rs
@@ -25,7 +25,7 @@ pub struct BlockConsensus {
   /// Consensus data byte-prefix
   pub tag: ByteTag,
   /// The proof-of-work challenge difficulty
-  pub difficulty: CCDifficulty,
+  pub expected_difficulty: CCDifficulty,
   /// The current server time, in UTC seconds
   pub timestamp: CCTimestamp,
   /// The proof-of-work nonce
@@ -62,7 +62,7 @@ impl BlockConsensus {
     let timestamp: Vec<u8> = Self::read_sequence(&mut reader, GLUE_BYTE)?;
     Ok(Self {
       tag,
-      difficulty: Self::parse_from_utf8("difficulty", &difficulty)?,
+      expected_difficulty: Self::parse_from_utf8("difficulty", &difficulty)?,
       timestamp: Self::parse_from_utf8("timestamp", &timestamp)?,
       nonce: Self::parse_from_utf8("nonce", &nonce)?,
     })
@@ -176,7 +176,7 @@ mod tests {
     let consensus = BlockConsensus::deserialize(consensus).unwrap();
 
     assert_eq!(&consensus.tag, POW_BYTES);
-    assert_eq!(consensus.difficulty, 30);
+    assert_eq!(consensus.expected_difficulty, 30);
     assert_eq!(consensus.nonce, 123);
     assert_eq!(consensus.timestamp, 500.555);
   }

--- a/src/block/block_header.rs
+++ b/src/block/block_header.rs
@@ -63,14 +63,14 @@ impl<'a> BlockHeader<'a> {
       self.consensus.nonce,
     );
 
-    let (is_valid, difficulty) = is_valid_proof_of_work(&hash, self.consensus.difficulty);
+    let (is_valid, difficulty) = is_valid_proof_of_work(&hash, self.consensus.expected_difficulty);
 
     if is_valid {
       Ok(difficulty)
     } else {
       Err(ConsensusError::InvalidHash(format!(
         "({} / diff:{})",
-        difficulty, self.consensus.difficulty
+        difficulty, self.consensus.expected_difficulty
       )))
     }
   }

--- a/src/block/block_header.rs
+++ b/src/block/block_header.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
 use crate::block::{Block, BlockConsensus, ConsensusError};
-use crate::primitives::H256;
+use crate::primitives::{CCDifficulty, H256};
 use crate::work::get_hasher;
 use crate::work::{is_valid_proof_of_work, mkhash};
 
@@ -36,7 +36,11 @@ impl<'a> BlockHeader<'a> {
   }
 
   pub fn work(&self) -> u64 {
-    2u64.pow(self.consensus.difficulty)
+    let actual_difficulty = self
+      .validate_proof_of_work()
+      .expect("Validity was previously attested when creating the BlockHeader");
+
+    2u64.pow(actual_difficulty)
   }
 
   pub fn validate(self) -> Result<Self, ConsensusError> {
@@ -46,12 +50,12 @@ impl<'a> BlockHeader<'a> {
     }
 
     // The block must pass the difficulty filter
-    self.validate_proof_of_work()?;
+    let _ = self.validate_proof_of_work()?;
 
     Ok(self)
   }
 
-  fn validate_proof_of_work(&self) -> Result<(), ConsensusError> {
+  fn validate_proof_of_work(&self) -> Result<CCDifficulty, ConsensusError> {
     let hash: H256 = mkhash(
       &mut get_hasher(),
       &self.previous_id,
@@ -62,7 +66,7 @@ impl<'a> BlockHeader<'a> {
     let (is_valid, difficulty) = is_valid_proof_of_work(&hash, self.consensus.difficulty);
 
     if is_valid {
-      Ok(())
+      Ok(difficulty)
     } else {
       Err(ConsensusError::InvalidHash(format!(
         "({} / diff:{})",

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,7 +44,7 @@ impl Engine for PowEngine {
     let rt = PowEngine::build_rt();
 
     {
-      let time_til_publishing = Duration::from_secs(node.config.seconds_between_blocks);
+      let time_til_publishing = Duration::from_millis(500);
       let stream = UpdateStream::new(updates, node, time_til_publishing);
 
       rt.block_on(stream.update_loop());

--- a/src/futures/update_stream.rs
+++ b/src/futures/update_stream.rs
@@ -52,13 +52,6 @@ impl UpdateStream {
     }
   }
 
-  /*
-  TODO
-  When new_chainhead:
-    reset timer.
-    if new_chainhead is not ours:
-      try fast-publish. abstract cancel block logic, insert cancel() if fast_publish fails.
-  */
   pub async fn update_loop(mut self) {
     let publishing_flag = self.publishing_flag.clone();
     let time = self.time_til_publishing;
@@ -96,7 +89,6 @@ impl UpdateStream {
           scheduler.set(PublishSchedulerFuture::schedule_publishing(publishing_flag.clone(), time).fuse());
           #[cfg(feature = "test-futures")]
           COUNT_COMMITTER.fetch_add(1usize, Ordering::Relaxed);
-          //force publish TODO?
           committer.set(UpdateStream::toggle_on_reactor(commit_flag.clone()).fuse());
         },
         _ = updater => break,

--- a/src/miner/answer.rs
+++ b/src/miner/answer.rs
@@ -1,7 +1,7 @@
 use crate::block::{BlockConsensus, SerializedBlockConsensus};
 use crate::miner::Challenge;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Answer {
   pub challenge: Challenge,
   pub nonce: u64,

--- a/src/miner/challenge.rs
+++ b/src/miner/challenge.rs
@@ -3,7 +3,7 @@ use crate::node::PeerId;
 use crate::primitives::{CCDifficulty, CCTimestamp};
 use std::fmt::{Debug, Formatter, Result};
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Challenge {
   pub difficulty: CCDifficulty,
   pub timestamp: CCTimestamp,

--- a/src/miner/miner.rs
+++ b/src/miner/miner.rs
@@ -169,11 +169,12 @@ mod test {
       };
     }
 
-    assert_eq!(consensus.difficulty, challenge.difficulty);
+    assert_eq!(consensus.expected_difficulty, challenge.difficulty);
 
     let hash: H256 = mkhash(&mut get_hasher(), &block_id, &peer_id, consensus.nonce);
 
-    let (is_valid, realized_difficulty) = is_valid_proof_of_work(&hash, consensus.difficulty);
+    let (is_valid, realized_difficulty) =
+      is_valid_proof_of_work(&hash, consensus.expected_difficulty);
     assert!(is_valid);
     assert!(realized_difficulty > challenge.difficulty);
 

--- a/src/miner/miner.rs
+++ b/src/miner/miner.rs
@@ -81,7 +81,10 @@ impl Debug for Miner {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::block::SerializedBlockConsensus;
+  use crate::block::{BlockConsensus, SerializedBlockConsensus};
+  use crate::primitives::H256;
+  use crate::work::{get_hasher, is_valid_proof_of_work, mkhash};
+
   #[test]
   fn default_miner() {
     let m = Miner::default();
@@ -137,5 +140,57 @@ mod test {
     }
 
     Ok(())
+  }
+  #[test]
+  ///The worker should return a challenge with expected difficulty not realized difficulty.
+  fn worker_returns_challenge_with_expected_difficulty() -> Result<(), String> {
+    let miner = Miner::default();
+    let block_id: Vec<u8> = b"1111111111111111".iter().copied().collect();
+    let peer_id: Vec<u8> = b"1111111111111111".iter().copied().collect();
+
+    let timestamp: f64 = utc_seconds_f64();
+
+    let challenge: Challenge = Challenge {
+      difficulty: 2,
+      timestamp,
+      block_id: block_id.clone(),
+      peer_id: peer_id.clone(),
+    };
+
+    miner.worker.send(challenge.clone());
+    while None == miner.try_create_consensus() {}
+
+    let consensus: BlockConsensus;
+    //the second answer if any is guaranteed to be higher than the expected difficulty but the expected diff should stay the same
+    loop {
+      if let Some(new) = miner.try_create_consensus() {
+        consensus = BlockConsensus::deserialize(new.as_slice()).unwrap();
+        break;
+      };
+    }
+
+    assert_eq!(consensus.difficulty, challenge.difficulty);
+
+    let hash: H256 = mkhash(&mut get_hasher(), &block_id, &peer_id, consensus.nonce);
+
+    let (is_valid, realized_difficulty) = is_valid_proof_of_work(&hash, consensus.difficulty);
+    assert!(is_valid);
+    assert!(realized_difficulty > challenge.difficulty);
+
+    //a new challenge should reset the current difficulty in the worker
+    miner.worker.send(challenge.clone());
+
+    while Some(MessageToMiner::Started) != miner.worker.try_recv() {}
+
+    std::thread::sleep(std::time::Duration::from_millis(250));
+
+    if let MessageToMiner::Solved(ans) = miner.worker.try_recv().unwrap() {
+      let hash: H256 = mkhash(&mut get_hasher(), &block_id, &peer_id, ans.nonce);
+      let (_, new_realized_difficulty) = is_valid_proof_of_work(&hash, ans.challenge.difficulty);
+      assert!(realized_difficulty > new_realized_difficulty);
+      Ok(())
+    } else {
+      Err("No answer received".into())
+    }
   }
 }

--- a/src/node/node.rs
+++ b/src/node/node.rs
@@ -137,7 +137,7 @@ impl PowNode {
       &config,
     );
 
-    if header.consensus.difficulty < expected_min_diff {
+    if header.consensus.expected_difficulty < expected_min_diff {
       debug!(
         "Failed consensus min diff check: curr {:?} - pred {:?}",
         &header, &pred_header

--- a/src/work.rs
+++ b/src/work.rs
@@ -66,7 +66,7 @@ fn calculate_difficulty(
   } else if is_adjustment_block(header, config) {
     calculate_adjustment_difficulty(header, timestamp, service, config)
   } else {
-    Ok(header.consensus.difficulty)
+    Ok(header.consensus.expected_difficulty)
   }
 }
 
@@ -84,7 +84,7 @@ fn calculate_tuning_difficulty(
     config.seconds_between_blocks,
   )?;
 
-  let difficulty: u32 = header.consensus.difficulty;
+  let difficulty: u32 = header.consensus.expected_difficulty;
 
   if time_taken < time_expected && difficulty < 255 {
     Ok(difficulty + 1)
@@ -109,7 +109,7 @@ fn calculate_adjustment_difficulty(
     config.seconds_between_blocks,
   )?;
 
-  let difficulty: u32 = header.consensus.difficulty;
+  let difficulty: u32 = header.consensus.expected_difficulty;
 
   if time_taken < time_expected / 2.0 && difficulty < 255 {
     Ok(difficulty + 1)


### PR DESCRIPTION
Using the actual difficulty as minimum difficulty is not stable. Use the expected difficulty as minimum difficulty.

The current publishing interval won’t let expected difficulty increase. Reduced it below sound publishing parameters.

Tests:

Algorithm version needs a bump in on-chain settings. Tested locally using battery energy options to increase/decrease hashing power and observe diff adjustment.

two-node setup not tested.

Publishing interval reduced to 500ms, low risk of affecting the publisher event loop. The publisher event loop could be simplified more in the future for performance and maintainability if the publishing interval is not required anymore.