### PR TITLE
Revert "ci: Flag CodeCov submissions in order to produce combined cov…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,12 @@ jobs:
           rm -rf target/
 
       - uses: codecov/codecov-action@v2
-        if: ${{ (matrix.toolchain == 'nightly') && (matrix.feature == '') }}
+        if: matrix.toolchain == 'nightly'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ steps.coverage.outputs.report }}
           fail_ci_if_error: true
           verbose: true
-          flags: ${{ matrix.feature }}
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
…erage"

b/c it looks like the `flags:` argument from the previous commit
doesn't work. In both cases the POST URL contains flags=&

https://codecov.freshdesk.com/support/tickets/6145

This reverts commit b67c2899b387087961333f145ec98c59b75b90e0.